### PR TITLE
Allow DeploymentConfig->map() to return values in standalone environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ### Unreleased
 
+### v1.2.1 (2019-11-15)
+
 * Allow DeploymentConfig->map() to return values in standalone environment
   This brings the `standalone` closer to the behaviour of other environments, except that it will
   continue to return null if there is nothing mapped (where other environments will throw). `->read`
-  continues to return null in standalone in every case. 
+  continues to return null in standalone in every case. Note that standalone will now return a value
+  if there's one mapped for `any` (`*`) - which is a minor breaking change to the behaviour of the 
+  standalone environment.
 
 ### v1.2.0 (2019-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Unreleased
 
+* Allow DeploymentConfig->map() to return values in standalone environment
+  This brings the `standalone` closer to the behaviour of other environments, except that it will
+  continue to return null if there is nothing mapped (where other environments will throw). `->read`
+  continues to return null in standalone in every case. 
+
 ### v1.2.0 (2019-11-12)
 
 * Add Base64Url StringEncoding helper class - like base64, but with entirely websafe characters for URLs etc

--- a/src/DeploymentConfig/DeploymentConfig.php
+++ b/src/DeploymentConfig/DeploymentConfig.php
@@ -148,15 +148,13 @@ class DeploymentConfig
 
     public function map(array ...$declarations)
     {
-        if ($this->environment === static::STANDALONE) {
-            return NULL;
-        }
-
         $map = $this->map_parser->parse($declarations);
         if (array_key_exists($this->environment, $map)) {
             $value = $map[$this->environment];
         } elseif (array_key_exists(static::ANY, $map)) {
             $value = $map[static::ANY];
+        } elseif ($this->environment === static::STANDALONE) {
+            return NULL;
         } else {
             throw MissingConfigException::missingMapValue($this->environment);
         }

--- a/test/unit/DeploymentConfig/DeploymentConfigTest.php
+++ b/test/unit/DeploymentConfig/DeploymentConfigTest.php
@@ -132,8 +132,9 @@ class DeploymentConfigTest extends TestCase
      *           ["qa", "i-am-prod-ish"]
      *           ["ci", null]
      *           ["imagined", "who-knows-what-i-am"]
+     *           ["standalone", "i-am-standalone"]
      */
-    public function test_its_map_environment_returns_value_or_default_for_the_current_env($env, $expect)
+    public function test_its_map_returns_value_or_default_for_the_current_env($env, $expect)
     {
         $subject = $this->newSubjectWithEnv($env);
         $this->assertSame(
@@ -142,16 +143,25 @@ class DeploymentConfigTest extends TestCase
                 ['dev', 'i-am-dev'],
                 [['prod', 'qa'], 'i-am-prod-ish'],
                 ['ci', NULL],
+                ['standalone', 'i-am-standalone'],
                 [DeploymentConfig::ANY, 'who-knows-what-i-am']
             )
         );
     }
 
-    public function test_its_map_returns_null_in_standalone_env()
+    /**
+     * @testWith ["dev"]
+     *           ["standalone"]
+     *           ["ci"]
+     */
+    public function test_its_map_returns_any_for_env_that_is_not_defined($env)
     {
-        $subject = $this->newSubjectWithEnv(DeploymentConfig::STANDALONE);
-        $this->assertNull(
-            $subject->map([DeploymentConfig::ANY, 'even `any` isn\'t taken'])
+        $subject = $this->newSubjectWithEnv($env);
+        $this->assertSame(
+            'I am anything',
+            $subject->map(
+                [DeploymentConfig::ANY, 'I am anything']
+            )
         );
     }
 
@@ -160,6 +170,18 @@ class DeploymentConfigTest extends TestCase
         $subject = $this->newSubjectWithEnv(DeploymentConfig::QA);
         $this->expectException(MissingConfigException::class);
         $subject->map([DeploymentConfig::PRODUCTION, 'prod']);
+    }
+
+    public function test_its_map_returns_null_for_standalone_if_nothing_defined()
+    {
+        $subject = $this->newSubjectWithEnv(DeploymentConfig::STANDALONE);
+        $this->assertSame(
+            NULL,
+            $subject->map(
+                [DeploymentConfig::DEV, 'I am dev'],
+                [DeploymentConfig::PRODUCTION, 'I am production']
+            )
+        );
     }
 
     public function test_its_map_decrypts_values()


### PR DESCRIPTION
This brings the `standalone` closer to the behaviour of other environments, except that it will
continue to return null if there is nothing mapped (where other environments will throw). `->read`
continues to return null in standalone in every case.