### PR TITLE
Fix MysqlSession to always return a value from releaseLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+### v1.4.1 (2020-02-17)
+
+* Fix missing return type from releaseLock when no lock is held
+
 ### v1.4.0 (2020-02-17)
 
 * Update MysqlSession to use strict sessions, SessionIdInterface and SessionUpdateTimestampHandlerInterface

--- a/src/Session/MysqlSession.php
+++ b/src/Session/MysqlSession.php
@@ -341,7 +341,7 @@ class MysqlSession implements SessionHandlerInterface, \SessionUpdateTimestampHa
         if ( ! $this->session_lock) {
             // The lock has already been released e.g. due to validateSid releasing it because
             // we did not have a valid claim on that ID (expired / fixation)
-            return;
+            return TRUE;
         }
 
         $query = $this->db->prepare("SELECT RELEASE_LOCK(:session_lock)");


### PR DESCRIPTION
Otherwise session_write_close reports errors.