### PR TITLE
Init DeviceIdentifier to fixed value in CLI without setting cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Init the DeviceIdentifier to a fixed value in the CLI environment without setting any cookies, to prevent
+  errors if the process has already sent output.
 * Add MutexWrapper with Mock and Db (mysql) backed implementations for preventing concurrent executions
   of code.
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### v1.5.0-beta3 (2020-10-09)
+
 * Init the DeviceIdentifier to a fixed value in the CLI environment without setting any cookies, to prevent
   errors if the process has already sent output.
 * Add MutexWrapper with Mock and Db (mysql) backed implementations for preventing concurrent executions

--- a/test/unit/Logging/DeviceIdentifierTest.php
+++ b/test/unit/Logging/DeviceIdentifierTest.php
@@ -154,7 +154,7 @@ class DeviceIdentifierTest extends TestCase
         $old_cookie = $_COOKIE;
         try {
             $_COOKIE['did'] = '1234567890123456789012';
-            DeviceIdentifier::initAndEnsureCookieSet(TRUE);
+            DeviceIdentifier::initAndEnsureCookieSet(TRUE, FALSE);
             $this->assertSame('1234567890123456789012', DeviceIdentifier::get());
 
             // Note that here the init method has assigned a global instance so changes to $_COOKIE
@@ -166,6 +166,18 @@ class DeviceIdentifierTest extends TestCase
             $_COOKIE = $old_cookie;
         }
         $this->assertSame('1234567890123456789012', DeviceIdentifier::get());
+    }
+
+    public function test_its_static_init_creates_instance_and_initialises_with_fixed_id_in_cli()
+    {
+        ScopeChangingCaller::call(
+            DeviceIdentifier::class,
+            function () { DeviceIdentifier::$instance = NULL; }
+        );
+
+        DeviceIdentifier::initAndEnsureCookieSet(TRUE); // Fall back to default arg
+        $this->assertSame(DeviceIdentifier::CLI_ID, DeviceIdentifier::get());
+        $this->assertRegExp(DeviceIdentifier::VALID_REGEX, DeviceIdentifier::get());
     }
 
     public function test_its_static_get_can_read_from_cookies_even_if_not_initialised()


### PR DESCRIPTION
This avoids the risk of errors setting the cookie if the process has
already sent output to the console.