### PR TITLE
Add helpers for microsecond-precision date/time values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### v1.7.0 (2020-11-16)
+
 * Add DateTimeImmutableFactory and DateString methods for dealing with microsecond-precision 
   date/time values
 * Improve test assertion API on the MockMutexWrapper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add DateTimeImmutableFactory and DateString methods for dealing with microsecond-precision 
+  date/time values
 * Improve test assertion API on the MockMutexWrapper
 
 ### v1.6.0 (2020-10-29)

--- a/src/DateTime/DateString.php
+++ b/src/DateTime/DateString.php
@@ -32,6 +32,19 @@ class DateString
     }
 
     /**
+     * Formats to ISO8601 (the real one not the PHP one :-O) with microsecond precision
+     *
+     * @param \DateTimeImmutable|null $date
+     * @param string                  $empty_value
+     *
+     * @return string
+     */
+    public static function isoMS(?\DateTimeImmutable $date, ?string $empty_value = ''): ?string
+    {
+        return static::format($date, 'Y-m-d\TH:i:s.uP', $empty_value);
+    }
+
+    /**
      * Formats as Y-m-d H:i:s
      *
      * @param \DateTimeImmutable|NULL $date

--- a/test/unit/DateTime/DateStringTest.php
+++ b/test/unit/DateTime/DateStringTest.php
@@ -62,4 +62,22 @@ class DateStringTest extends TestCase
         $this->assertSame($expect, DateString::ymd($date, $fallback));
     }
 
+    public function provider_isoms()
+    {
+        $lndn = new \DateTimeZone('Europe/London');
+
+        return [
+            [NULL, 'nothing', 'nothing'],
+            [new \DateTimeImmutable('2020-08-21 12:15:54.643214', $lndn), '', '2020-08-21T12:15:54.643214+01:00'],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_isoms
+     */
+    public function test_it_formats_to_iso8601_with_milliseconds($date, $fallback, $expect)
+    {
+        $this->assertSame($expect, DateString::isoMS($date, $fallback));
+    }
+
 }

--- a/test/unit/DateTime/DateTimeImmutableFactoryTest.php
+++ b/test/unit/DateTime/DateTimeImmutableFactoryTest.php
@@ -134,4 +134,24 @@ class DateTimeImmutableFactoryTest extends TestCase
         }
     }
 
+    /**
+     * @testWith [1598008554.643, "2020-08-21T12:15:54.643000+01:00"]
+     *           ["1598008554.64321424", "2020-08-21T12:15:54.643214+01:00"]
+     *           ["1274437650", "2010-05-21T11:27:30.000000+01:00"]
+     *           [1274437650, "2010-05-21T11:27:30.000000+01:00"]
+     *           [1274437650.0, "2010-05-21T11:27:30.000000+01:00"]
+     */
+    public function test_it_factories_from_microtime_in_default_tz($val, $expect)
+    {
+        try {
+            $old_default = \date_default_timezone_get();
+            \date_default_timezone_set('Europe/London');
+            $actual = DateTimeImmutableFactory::atMicrotime($val);
+            $this->assertSame('Europe/London', $actual->getTimezone()->getName());
+            $this->assertSame($expect, $actual->format('Y-m-d\TH:i:s.uP'));
+        } finally {
+            \date_default_timezone_set($old_default);
+        }
+    }
+
 }


### PR DESCRIPTION
Helper to parse a microsecond datetime value, and to render it as a
full-precision ISO8601 string.