### PR TITLE
StoppedMockClock now accepts and returns fractional seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* [CAUTION] StoppedMockClock now stores / returns fractional seconds for consistency with real DateTimeImmutable
+  PHP DateTime objects now always carry microseconds - the StoppedMockClock should therefore always include them
+  in the times it accepts and returns. There is a possibility this will cause some strict equality checks in
+  unit tests to fail. Not treated as a package breaking release as it only affects testcase code.
 * Add ObjectPropertyRipper::ripAll to grab all variables (from simple objects with no private props in
   parent classes).
 

--- a/src/DateTime/Clock/StoppedMockClock.php
+++ b/src/DateTime/Clock/StoppedMockClock.php
@@ -7,6 +7,7 @@
 namespace Ingenerator\PHPUtils\DateTime\Clock;
 
 use Ingenerator\PHPUtils\DateTime\Clock\RealtimeClock;
+use Ingenerator\PHPUtils\DateTime\DateTimeImmutableFactory;
 use PHPUnit\Framework\Assert;
 
 class StoppedMockClock extends RealtimeClock
@@ -26,7 +27,7 @@ class StoppedMockClock extends RealtimeClock
      */
     protected function __construct(\DateTimeImmutable $start_time)
     {
-        $this->current_microtime = (float) $start_time->getTimestamp();
+        $this->current_microtime = (float) $start_time->format('U.u');
     }
 
     /**
@@ -36,10 +37,7 @@ class StoppedMockClock extends RealtimeClock
      */
     public static function atMicrotime($microtime)
     {
-        $inst                    = new static(new \DateTimeImmutable);
-        $inst->current_microtime = $microtime;
-
-        return $inst;
+        return new static(DateTimeImmutableFactory::atMicrotime($microtime));
     }
 
     /**
@@ -79,7 +77,7 @@ class StoppedMockClock extends RealtimeClock
 
     public function getDateTime()
     {
-        return (new \DateTimeImmutable)->setTimestamp(\floor($this->current_microtime));
+        return DateTimeImmutableFactory::atMicrotime($this->current_microtime);
     }
 
     public function getMicrotime()

--- a/test/unit/DateTime/Clock/StoppedMockClockTest.php
+++ b/test/unit/DateTime/Clock/StoppedMockClockTest.php
@@ -34,6 +34,11 @@ class StoppedMockClockTest extends TestCase
                 new \DateTimeImmutable('2019-03-04 10:02:03'),
                 1551693723.0
             ],
+            [
+                new \DateTimeImmutable('2019-03-04 10:02:03.248123'),
+                new \DateTimeImmutable('2019-03-04 10:02:03.248123'),
+                1551693723.248123
+            ],
         ];
     }
 
@@ -52,7 +57,7 @@ class StoppedMockClockTest extends TestCase
     {
         $clock = StoppedMockClock::atMicrotime(1551693723.1239);
         $this->assertSame(1551693723.1239, $clock->getMicrotime());
-        $this->assertSame('2019-03-04 10:02:03', $clock->getDateTime()->format('Y-m-d H:i:s'));
+        $this->assertSame('2019-03-04 10:02:03.123900', $clock->getDateTime()->format('Y-m-d H:i:s.u'));
     }
 
     public function test_it_is_initialisable_at_a_date_interval_in_the_past()
@@ -85,16 +90,16 @@ class StoppedMockClockTest extends TestCase
     public function test_it_advances_time_after_each_tick_microseconds()
     {
         $clock = StoppedMockClock::atMicrotime(1546682582.150);
-        $this->assertEquals(new \DateTimeImmutable('2019-01-05 10:03:02'), $clock->getDateTime());
+        $this->assertEquals(new \DateTimeImmutable('2019-01-05 10:03:02.150'), $clock->getDateTime());
 
         $clock->tickMicroseconds(150000);
         $this->assertSame(1546682582.300, \round($clock->getMicrotime(), 3));
-        $this->assertEquals(new \DateTimeImmutable('2019-01-05 10:03:02'), $clock->getDateTime(), 'DateTime not changed by sub-second tick');
+        $this->assertEquals(new \DateTimeImmutable('2019-01-05 10:03:02.300'), $clock->getDateTime(), 'DateTime not changed by sub-second tick');
 
 
         $clock->tickMicroseconds(750000);
         $this->assertSame(1546682583.050, \round($clock->getMicrotime(), 3));
-        $this->assertEquals(new \DateTimeImmutable('2019-01-05 10:03:03'), $clock->getDateTime(), 'DateTime changed after second boundary');
+        $this->assertEquals(new \DateTimeImmutable('2019-01-05 10:03:03.050'), $clock->getDateTime(), 'DateTime changed after second boundary');
     }
 
     public function test_its_usleep_is_immediate_but_advances_time()


### PR DESCRIPTION
PHP DateTime objects now always carry microseconds - the
StoppedMockClock should therefore always include them in the times
it accepts and returns to ensure the behaviour is consistent with
the real clock. There is a possibility this will cause some strict
equality checks in unit tests to fail. Not treated as a package
breaking release as it only affects testcase code.