### PR TITLE
Fix request memory logging to use the 'real' system memory used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Unreleased
 
+### v1.14.1 (2021-11-22)
+
+* [BUG] Request memory usage logs introduced in 1.14 should have been reporting the "real" memory usage
+  e.g. `memory_get_peak_usage(TRUE)` rather than the less reliable emalloc based allocations php returns by
+  default.
+
 ### v1.14.0 (2021-11-19)
 
 * StackdriverApplicationLogger: limit length of user-agent string in request logs to a maximum of 500 bytes.

--- a/src/Logging/StackdriverApplicationLogger.php
+++ b/src/Logging/StackdriverApplicationLogger.php
@@ -380,7 +380,7 @@ class StackdriverApplicationLogger extends AbstractLogger
                 self::PROP_INGEN_TYPE => 'rqst',
                 'httpRequest'         => $meta['context']['httpRequest'] ?? [],
                 'context' => [
-                    'mem_mb' => sprintf('%.2f',\memory_get_peak_usage() / 1_000_000),
+                    'mem_mb' => sprintf('%.2f',\memory_get_peak_usage(TRUE) / 1_000_000),
                 ],
             ],
             $meta,

--- a/test/unit/Logging/StackdriverApplicationLoggerTest.php
+++ b/test/unit/Logging/StackdriverApplicationLoggerTest.php
@@ -602,9 +602,9 @@ class StackdriverApplicationLoggerTest extends TestCase
     public function test_its_request_logger_logs_peak_memory_usage_in_mb()
     {
         $logger      = $this->newSubject();
-        $peak_before = \memory_get_peak_usage();
+        $peak_before = \memory_get_peak_usage(TRUE);
         $logger->logRequest([]);
-        $peak_after = \memory_get_peak_usage();
+        $peak_after = \memory_get_peak_usage(TRUE);
         $entry      = $this->assertLoggedOneLine();
         $this->assertIsString(
             $entry['context']['mem_mb'],


### PR DESCRIPTION
Forgot to specify the `true` argument to `memory_get_peak_usage`.