### PR TITLE
Make DbBackedMutexWrapper locking type-safe with PDO_MYSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fix deprecation warning when passing NULL to date validator by casting 
   to empty string to maintain current behaviour.
 
+* Make DbBackedMutexWrapper locking type-safe across PHP versions
+
 ### v1.17.0 (2022-10-14)
 
 * Support PHP 8.2

--- a/src/Mutex/DbBackedMutexWrapper.php
+++ b/src/Mutex/DbBackedMutexWrapper.php
@@ -40,7 +40,10 @@ class DbBackedMutexWrapper implements MutexWrapper
             ->query("SELECT GET_LOCK($name_param, $timeout_seconds)")
             ->fetchAll(PDO::FETCH_COLUMN, 0);
 
-        if ($result[0] !== '1') {
+        // Need to explicitly cast the result to an int for comparison as PDO value types vary between 8.0 and 8.1+
+        // And we should keep this cast even when we drop 8.0, because the PDO int/string mode is actually
+        // configurable with a PDO attribute so could vary at runtime too.
+        if (1 !== (int) $result[0]) {
             throw new MutexTimedOutException($name, $timeout_seconds, $result);
         }
     }

--- a/test/unit/Mutex/BasicPDOStatementStub.php
+++ b/test/unit/Mutex/BasicPDOStatementStub.php
@@ -40,6 +40,18 @@ if (PHP_MAJOR_VERSION < 8) {
 
         public function fetchAll(int $fetch_style = NULL, mixed ...$fetch_argument): array
         {
+            if (PHP_VERSION_ID < 80100) {
+                // Before 8.1, ints and floats were returned as strings
+                // https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql
+                $this->result = array_map(
+                    fn($row) => array_map(
+                        fn($column) => (is_int($column) || \is_float($column)) ? (string) $column : $column,
+                        $row
+                    ),
+                    $this->result
+                );
+            }
+
             if ($fetch_style === NULL) {
                 return $this->result;
             } elseif ($fetch_style === PDO::FETCH_COLUMN) {

--- a/test/unit/Mutex/DbBackedMutexWrapperTest.php
+++ b/test/unit/Mutex/DbBackedMutexWrapperTest.php
@@ -29,11 +29,11 @@ class DbBackedMutexWrapperTest extends TestCase
             [
                 [
                     'sql'    => 'SELECT GET_LOCK({quoted-mylock}, 5)',
-                    'result' => [['0']]
+                    'result' => [[0]]
                 ],
                 [
                     'sql'    => 'SELECT RELEASE_LOCK({quoted-mylock})',
-                    'result' => [['0']]
+                    'result' => [[0]]
                 ],
             ]
         );
@@ -53,11 +53,11 @@ class DbBackedMutexWrapperTest extends TestCase
             [
                 [
                     'sql'    => 'SELECT GET_LOCK({quoted-somelock}, 2)',
-                    'result' => [['1']]
+                    'result' => [[1]]
                 ],
                 [
                     'sql'    => 'SELECT RELEASE_LOCK({quoted-somelock})',
-                    'result' => [['0']]
+                    'result' => [[0]]
                 ],
             ]
         );
@@ -80,11 +80,11 @@ class DbBackedMutexWrapperTest extends TestCase
             [
                 [
                     'sql'    => 'SELECT GET_LOCK({quoted-somelock}, 2)',
-                    'result' => [['1']]
+                    'result' => [[1]]
                 ],
                 [
                     'sql'    => 'SELECT RELEASE_LOCK({quoted-somelock})',
-                    'result' => [['0']]
+                    'result' => [[0]]
                 ],
             ]
         );


### PR DESCRIPTION
Due to PDO_MYSQL changing behaviour and returning ints as ints instead of strings. Obviously can't actually prove this on a DB connection in these unit tests, but the mock now mirrors PDO behaviour depending on PHP version.