### PR TITLE
Fix StrictDate::date_after tests & deprecate validating InvalidUserDateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* Fix tests for StrictDate::date_after
+* Deprecate all StrictDate:: validation methods related to the deprecated `InvalidUserDateTime` object - validate
+  date inputs either as strings *or* as (valid) date objects, not both.
+
 ### v1.17.1 (2022-10-28)
 
 * Fix deprecation warning when passing NULL to date validator by casting 

--- a/src/Validation/StrictDate.php
+++ b/src/Validation/StrictDate.php
@@ -19,6 +19,8 @@ class StrictDate
      * @param string       $from_field
      * @param string       $to_field
      *
+     * @deprecated validate input before creating DateTimeImmutable objects
+     *
      * @return bool
      */
     public static function date_after(\ArrayAccess $validation, $from_field, $to_field)
@@ -40,6 +42,8 @@ class StrictDate
      * @param string       $from_field
      * @param string       $to_field
      *
+     * @deprecated validate input before creating DateTimeImmutable objects
+     *
      * @return bool
      */
     public static function date_on_or_after(\ArrayAccess $validation, $from_field, $to_field)
@@ -58,6 +62,8 @@ class StrictDate
      * @param \ArrayAccess $validation
      * @param string       $from_field
      * @param string       $to_field
+     *
+     * @deprecated validate input before creating DateTimeImmutable objects
      *
      * @return \DateTimeImmutable[]
      */
@@ -82,6 +88,8 @@ class StrictDate
      *
      * @param mixed $value
      *
+     * @deprecated validate input before creating DateTimeImmutable objects
+     *
      * @return bool
      */
     public static function date_immutable($value)
@@ -93,6 +101,8 @@ class StrictDate
      * Value is NULL or a valid DateTimeImmutable - not an InvalidUserDateTime
      *
      * @param mixed $value
+     *
+     * @deprecated validate input before creating DateTimeImmutable objects
      *
      * @return bool
      */

--- a/test/unit/Validation/StrictDateTest.php
+++ b/test/unit/Validation/StrictDateTest.php
@@ -109,11 +109,20 @@ class StrictDateTest extends TestCase
         );
     }
 
+    public function provider_date_after_date()
+    {
+        return [
+            'long before'   => ['2022-10-02 13:04:03', '2015-11-02 10:03:02', FALSE],
+            'just before'   => ['2022-10-02 13:01:03.999999', '2022-10-02 13:01:03.999998', FALSE],
+            'exact moment'  => ['2022-10-02 13:01:03.999999', '2022-10-02 13:01:03.999999', FALSE],
+            'just after'    => ['2022-10-02 13:01:03.999999', '2022-10-02 13:01:04.000000', TRUE],
+            'seconds after' => ['2022-10-02 13:01:03', '2022-10-02 13:01:06.000000', TRUE],
+            'long after'    => ['2022-10-02 13:01:03', '2023-03-05 18:01:06.000000', TRUE],
+        ];
+    }
+
     /**
-     * @testWith ["", "-5 mins", false]
-     *           [null, "", true]
-     *           ["", null, true]
-     *           ["-5 mins", "", true]
+     * @dataProvider provider_date_after_date
      */
     public function test_it_validates_date_after_date($from, $to, $expect)
     {
@@ -122,8 +131,8 @@ class StrictDateTest extends TestCase
             StrictDate::date_after(
                 new \ArrayObject(
                     [
-                        'from' => new \DateTimeImmutable((string) $from),
-                        'to'   => new \DateTimeImmutable((string) $to)
+                        'from' => new \DateTimeImmutable($from),
+                        'to'   => new \DateTimeImmutable($to),
                     ]
                 ),
                 'from',


### PR DESCRIPTION
The ::date_after, ::date_immutable etc validators are designed to be used with a data array that already contains either DateTimeImmutable or our placeholder InvalidUserDateTime objects. This worked for a while but is a problematic data / logic structure - deprecate in favour of deciding whether your app is going to validate input as strings *or* as datetimes.