### PR TITLE
Update JSON::decode to throw on null instead of catching ErrorException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 ### Unreleased
 
+### v1.17.2 (2022-10-31)
+
+* Update `JSON::decode` to throw an explicit exception on NULL input
+  This has always actually thrown an InvalidJSONException, but it used to be indistinguishable
+  from the `Syntax error` produced by empty/invalid JSON strings.
+
+* Revert change in v1.16.0 that caught all `ErrorException` in `JSON::decode` - these will now
+  bubble as previously.
+
 * Fix tests for StrictDate::date_after
+
 * Deprecate all StrictDate:: validation methods related to the deprecated `InvalidUserDateTime` object - validate
   date inputs either as strings *or* as (valid) date objects, not both.
 

--- a/src/StringEncoding/JSON.php
+++ b/src/StringEncoding/JSON.php
@@ -10,14 +10,18 @@ class JSON
 
     public static function decode(?string $json)
     {
-        try {
-            $result = json_decode($json, TRUE);
-        } catch (\ErrorException $e){
-            throw new InvalidJSONException('Invalid JSON: ' . json_last_error_msg());
+        // NOTE: it is deprecated to call this with a null argument, which has always thrown an InvalidJSONException.
+        // The typehint is left as ?string for backwards compatibility
+        if ($json === NULL) {
+            throw new InvalidJSONException('Invalid JSON: Cannot decode a null value');
         }
+
+        $result = json_decode($json, TRUE);
+
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new InvalidJSONException('Invalid JSON: ' . json_last_error_msg());
+            throw new InvalidJSONException('Invalid JSON: '.json_last_error_msg());
         }
+
         return $result;
     }
 

--- a/test/unit/StringEncoding/JSONTest.php
+++ b/test/unit/StringEncoding/JSONTest.php
@@ -31,13 +31,14 @@ class JSONTest extends TestCase
     }
 
     /**
-     * @testWith [null]
-     *           [""]
-     *           ["i am not json"]
+     * @testWith [null, "Cannot decode a null value"]
+     *           ["", "Syntax error"]
+     *           ["i am not json", "Syntax error"]
      */
-    public function test_it_throws_on_parsing_invalid_json($value)
+    public function test_it_throws_on_parsing_invalid_json($value, $expect_msg)
     {
         $this->expectException(InvalidJSONException::class);
+        $this->expectExceptionMessage($expect_msg);
         JSON::decode($value);
     }
 


### PR DESCRIPTION
Restore the exception behaviour to match that prior to v1.16.0, but introduce a new explicit exception message when the input is null.