### PR TITLE
Add light wrapper around native anonymous public key encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Add a UniqueMap data structure class, for a strict associative array that throws on attempt to overwrite a key.
 * Drop support for PHP 8.0
 
 ### v1.18.0 (2022-12-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ### Unreleased
 
+* Add very light wrapper around the native sodium_crypto_box_seal... functions for anonymous public-key encryption.
+  See the CryptoBox... classes. Provides strict typing, some automatic handling of secret memory (e.g. calling
+  memzero on sensitive variables after use), a simple implementation of converting keys & ciphertexts to / from
+  url-safe base64, and a basic mechanism to support key rotation with a fixed list of active keypairs.
+
 * Add a UniqueMap data structure class, for a strict associative array that throws on attempt to overwrite a key.
+
 * Drop support for PHP 8.0
 
 ### v1.18.0 (2022-12-15)

--- a/src/ArrayHelpers/DuplicateMapItemException.php
+++ b/src/ArrayHelpers/DuplicateMapItemException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\ArrayHelpers;
+
+use RuntimeException;
+use UnexpectedValueException;
+
+class DuplicateMapItemException extends UnexpectedValueException
+{
+
+}

--- a/src/ArrayHelpers/UniqueMap.php
+++ b/src/ArrayHelpers/UniqueMap.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\ArrayHelpers;
+
+use ArrayAccess;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+use function array_key_exists;
+
+/**
+ * A generic Map collection that prevents overwriting keys or accessing undefined keys.
+ *
+ * Basically, a strict associative array where each position in the array is readonly (although
+ * you can delete an item and then assign a new one).
+ *
+ * Note that you can still explicitly access it like `$foo = $map['undefined'] ?? 'default'` if
+ * you want to access a key that may or may not exist (just like a standard array).
+ */
+class UniqueMap implements ArrayAccess, IteratorAggregate, Countable
+{
+
+
+    /**
+     * @param array<string,mixed> $items initial items to put in the map
+     */
+    public function __construct(private array $items = [])
+    {
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->items);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        if ( ! isset($this->items[$offset])) {
+            throw new \OutOfBoundsException('No item with key '.$offset);
+        }
+
+        return $this->items[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if (array_key_exists($offset, $this->items)) {
+            throw new DuplicateMapItemException('Map already contains an item with key '.$offset);
+        }
+
+        $this->items[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->items[$offset]);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+}

--- a/src/Encryption/CryptoBox/CryptoBoxKeypair.php
+++ b/src/Encryption/CryptoBox/CryptoBoxKeypair.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\TrustIDIngress\ToExtract\SensitiveParameter;
+use SodiumException;
+use function preg_match;
+use function sodium_base642bin;
+use function sodium_bin2base64;
+use function sodium_crypto_box_keypair;
+use function sodium_crypto_box_publickey;
+use function sodium_crypto_box_seal_open;
+use function sodium_memzero;
+use const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
+
+/**
+ * Models a secret keypair used to decrypt values with sodium_crypto_box_seal_open
+ *
+ * Wrapping the keypair in an object allows this instance to be passed around without making copies
+ * of the keypair in memory.
+ */
+class CryptoBoxKeypair
+{
+    private CryptoBoxPublicKey $public_key;
+
+    /**
+     * Create an instance from a string that was previously exported from this library
+     *
+     * @param string $exported
+     *
+     * @return static
+     */
+    public static function fromString(
+        #[\SensitiveParameter]
+        string $exported
+    ): static {
+        if ( ! preg_match('/(?P<keypair_id>[a-z0-9-]+)\.(?P<keypair_b64>[a-zA-Z0-9_-]+)$/', $exported, $matches)) {
+            throw new \InvalidArgumentException('Invalid keypair string format');
+        }
+
+        try {
+            // Use constant-time base64 decoding to avoid timing attacks
+            $keypair = sodium_base642bin($matches['keypair_b64'], SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+
+            return new static(
+                keypair: $keypair,
+                keypair_id: $matches['keypair_id']
+            );
+        } finally {
+            sodium_memzero($exported);
+            if (isset($keypair)) {
+                sodium_memzero($keypair);
+            }
+        }
+    }
+
+
+    /**
+     * Randomly generate a new keypair
+     *
+     * @param string $keypair_id
+     *
+     * @return static
+     * @throws SodiumException
+     */
+    public static function generate(string $keypair_id): static
+    {
+        if ( ! preg_match('/^(?P<keypair_id>[a-z0-9-]+)$/', $keypair_id)) {
+            throw new \InvalidArgumentException('keypair_id must consist of a-z0-9 only');
+        }
+
+        $keypair = sodium_crypto_box_keypair();
+        try {
+            return new static(
+                keypair: $keypair,
+                keypair_id: $keypair_id,
+            );
+        } finally {
+            sodium_memzero($keypair);
+        }
+
+    }
+
+    /**
+     * @param string $keypair The raw binary string for the keypair
+     * @param string $keypair_id An application-level identifier for this keypair
+     */
+    protected function __construct(
+        // $keypair can't be readonly because we need to zero the memory on destruct
+        #[SensitiveParameter]
+        private string $keypair,
+        public readonly string $keypair_id
+    ) {
+        // Creating the public key now is the easiest way to validate that the incoming keypair string is actually valid
+        try {
+            $this->public_key = new CryptoBoxPublicKey(sodium_crypto_box_publickey($this->keypair), $this->keypair_id);
+        } catch (SodiumException $e) {
+            throw new \InvalidArgumentException('Invalid keypair: '.$e->getMessage());
+        }
+    }
+
+    public function __destruct()
+    {
+        // Ensure that our local copy of the private key is securely removed from memory
+        if (isset($this->keypair)) {
+            sodium_memzero($this->keypair);
+        }
+    }
+
+    public function getPublicKey(): CryptoBoxPublicKey
+    {
+        return $this->public_key;
+    }
+
+    /**
+     * Decrypt a value that was previously encrypted with the public key
+     *
+     * @param CryptoBoxString $encrypted
+     *
+     * @return string
+     * @throws DecryptionFailedException if the keypair ID is incorrect, the ciphertext has been tampered with, or value was not encrypted for this keypair
+     */
+    public function decrypt(CryptoBoxString $encrypted): string
+    {
+        if ($encrypted->keypair_id !== $this->keypair_id) {
+            throw new DecryptionFailedException(
+                'Failed to decrypt - incorrect keypair provided'
+            );
+        }
+
+        try {
+            $result = sodium_crypto_box_seal_open($encrypted->ciphertext, $this->keypair);
+            if ($result === false) {
+                throw new DecryptionFailedException('Failed to decrypt - invalid key or ciphertext?');
+            }
+
+            return $result;
+
+        } catch (SodiumException $e) {
+            throw new DecryptionFailedException('Failed to decrypt: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Create a string/base64 representation of the keypair.
+     *
+     * Note, intentionally not using `Stringable` for this because exporting the private keypair should be an explicit
+     * action, not something that happens accidentally on a typecast / debug printout etc.
+     *
+     * @return string
+     */
+    public function exportToString(): string
+    {
+        // Use constant-time base64 decoding to avoid timing attacks
+        return $this->keypair_id.'.'.sodium_bin2base64($this->keypair, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+    }
+
+}

--- a/src/Encryption/CryptoBox/CryptoBoxKeypairSet.php
+++ b/src/Encryption/CryptoBox/CryptoBoxKeypairSet.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\ArrayHelpers\UniqueMap;
+use OutOfBoundsException;
+use SensitiveParameter;
+use function sodium_memzero;
+
+/**
+ * Represents a set of known keypairs, from which the correct decryption key can be selected
+ *
+ * Used primarily to support key rotation, load a keypairset with all currently active keys to
+ * allow loading both old and new values.
+ */
+class CryptoBoxKeypairSet
+{
+    private UniqueMap $keys;
+
+    /**
+     * Create from an array of keypair strings previously exported from this library
+     *
+     * @param string ...$keypair_strings
+     *
+     * @return static
+     */
+    public static function fromStrings(
+        #[SensitiveParameter]
+        string ...$keypair_strings
+    ): static {
+        $keypairs = [];
+        foreach ($keypair_strings as &$kp) {
+            try {
+                $keypairs[] = CryptoBoxKeypair::fromString($kp);
+            } finally {
+                // Clear our copy of the keypair string
+                sodium_memzero($kp);
+            }
+        }
+
+        return new static(...$keypairs);
+    }
+
+    public function __construct(
+        CryptoBoxKeypair ...$keys
+    ) {
+        $this->keys = new UniqueMap([]);
+        foreach ($keys as $key) {
+            $this->keys[$key->keypair_id] = $key;
+        }
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return CryptoBoxKeypair
+     * @throws OutOfBoundsException if the key is not loaded
+     */
+    public function getKeypair(string $id): CryptoBoxKeypair
+    {
+        return $this->keys[$id];
+    }
+
+    /**
+     * Pick the correct key & decrypt the value
+     *
+     * @param CryptoBoxString $encrypted
+     *
+     * @return string
+     * @throws OutOfBoundsException if the key is not loaded
+     */
+    public function decrypt(CryptoBoxString $encrypted): string
+    {
+        return $this
+            ->getKeypair($encrypted->keypair_id)
+            ->decrypt($encrypted);
+    }
+}

--- a/src/Encryption/CryptoBox/CryptoBoxPublicKey.php
+++ b/src/Encryption/CryptoBox/CryptoBoxPublicKey.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\StringEncoding\Base64Url;
+use SensitiveParameter;
+use Stringable;
+use function preg_match;
+use function sodium_crypto_box_seal;
+use function sodium_memzero;
+use function strlen;
+use const SODIUM_CRYPTO_BOX_PUBLICKEYBYTES;
+
+/**
+ * Represents the public key of a keypair, together with an identifier to support key rotation
+ */
+class CryptoBoxPublicKey implements Stringable
+{
+
+    public static function fromString(string $exported): static
+    {
+        if ( ! preg_match('/(?P<keypair_id>[a-z0-9-]+)\.(?P<key_b64>[a-zA-Z0-9_-]+)$/', $exported, $matches)) {
+            throw new \InvalidArgumentException('Invalid public key string format');
+        }
+
+
+        return new static(
+            public_key: Base64Url::decode($matches['key_b64']),
+            // public key is not secret, no need for constant-time encoding
+            keypair_id: $matches['keypair_id']
+        );
+    }
+
+    public function __construct(
+        /**
+         * The public key in raw binary form
+         */
+        public readonly string $public_key,
+        /**
+         * An ID to support key rotation
+         */
+        public readonly string $keypair_id
+    ) {
+        if (strlen($this->public_key) !== SODIUM_CRYPTO_BOX_PUBLICKEYBYTES) {
+            throw new \InvalidArgumentException('Invalid public key - incorrect length');
+        }
+    }
+
+    public function encrypt(
+        #[SensitiveParameter]
+        string $plaintext
+    ): CryptoBoxString {
+        try {
+            return new CryptoBoxString(
+                ciphertext: sodium_crypto_box_seal($plaintext, $this->public_key),
+                keypair_id: $this->keypair_id
+            );
+        } finally {
+            // Ensure our copy of the sensitive data is cleared from memory
+            sodium_memzero($plaintext);
+        }
+    }
+
+    public function __toString(): string
+    {
+        // public key is not secret, no need for constant-time encoding
+        return $this->keypair_id.'.'.Base64Url::encode($this->public_key);
+    }
+}

--- a/src/Encryption/CryptoBox/CryptoBoxString.php
+++ b/src/Encryption/CryptoBox/CryptoBoxString.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\StringEncoding\Base64Url;
+use Stringable;
+use function preg_match;
+
+class CryptoBoxString implements Stringable
+{
+
+    /**
+     * Hydrate from a value that has previously been serialized to a string
+     *
+     * @param string $exported of the format '{key_id}.{base64url-encoded-ciphertext}'
+     *
+     * @return static
+     *
+     * @see CryptoBoxString::__toString()
+     */
+    public static function fromString(string $exported): static
+    {
+        if ( ! preg_match('/(?P<keypair_id>[a-z0-9-]+)\.(?P<ciphertext_b64>[a-zA-Z0-9_-]+)$/', $exported, $matches)) {
+            throw new \InvalidArgumentException('Invalid ciphertext string format');
+        }
+        
+        return new static(
+            ciphertext: Base64Url::decode($matches['ciphertext_b64']),
+            // ciphertext is not secret, no need for constant-time encoding
+            keypair_id: $matches['keypair_id']
+        );
+    }
+
+    public function __construct(
+        public readonly string $ciphertext,
+        public readonly string $keypair_id,
+    ) {
+
+    }
+
+    /**
+     * Formats as `{key_id}.{base64url-encoded-ciphertext}` for persistence & storage
+     *
+     * @return string
+     *
+     * @see CryptoBoxString::fromString()
+     */
+    public function __toString(): string
+    {
+        // ciphertext is not private, no need to use constant-time encoding
+        return $this->keypair_id.'.'.Base64Url::encode($this->ciphertext);
+    }
+
+    /**
+     * Utility method to give a base64 encoded version of the ciphertext
+     *
+     * @return string
+     */
+    public function getCiphertextB64(): string
+    {
+        // ciphertext is not private, no need to use constant-time encoding
+        return Base64Url::encode($this->ciphertext);
+    }
+
+}

--- a/src/Encryption/CryptoBox/DecryptionFailedException.php
+++ b/src/Encryption/CryptoBox/DecryptionFailedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+class DecryptionFailedException extends \RuntimeException
+{
+
+
+}

--- a/test/unit/ArrayHelpers/UniqueMapTest.php
+++ b/test/unit/ArrayHelpers/UniqueMapTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace test\unit\Ingenerator\PHPUtils\ArrayHelpers;
+
+use Ingenerator\PHPUtils\ArrayHelpers\DuplicateMapItemException;
+use Ingenerator\PHPUtils\ArrayHelpers\UniqueMap;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+use function iterator_to_array;
+
+class UniqueMapTest extends TestCase
+{
+
+
+    public function test_it_returns_entries_by_key()
+    {
+        $bar = new class { };
+        $subject = new UniqueMap(
+            [
+                'foo' => 'some-foo',
+                'bar' => $bar,
+            ]
+        );
+        $this->assertSame($bar, $subject['bar']);
+        $this->assertSame('some-foo', $subject['foo']);
+    }
+
+    public function test_it_throws_on_access_to_undefined_key()
+    {
+        $subject = new UniqueMap(['any' => 'item']);
+        $this->expectException(OutOfBoundsException::class);
+        $subject['other-item'];
+    }
+
+    public function test_it_accepts_new_items()
+    {
+        $new1 = new class { };
+        $subject = new UniqueMap(['any' => 'item']);
+        $subject['new1'] = $new1;
+        $subject['new2'] = 'some-string';
+
+        $this->assertSame($new1, $subject['new1']);
+        $this->assertSame('some-string', $subject['new2']);
+    }
+
+    public function test_it_throws_on_attempt_to_overwrite_key()
+    {
+        $subject = new UniqueMap(['any' => 'item']);
+
+        try {
+            $subject['any'] = 'anything';
+            $this->fail('Expected an exception, none got');
+        } catch (DuplicateMapItemException $e) {
+            $this->assertStringContainsString('any', $e->getMessage(), 'Includes key in exception message');
+            $this->assertSame('item', $subject['any'], 'Original item unmodified');
+        }
+    }
+
+    public function test_it_reports_if_an_item_exists()
+    {
+        $subject = new UniqueMap(['any' => 'item']);
+        $subject['other'] = 'thing';
+
+        $this->assertSame(
+            ['any' => true, 'other' => true, 'random' => false],
+            [
+                'any' => isset($subject['any']),
+                'other' => isset($subject['other']),
+                'random' => isset($subject['random']),
+            ]
+        );
+    }
+
+    public function test_it_allows_items_to_be_deleted_and_reinserted()
+    {
+        $subject = new UniqueMap(['any' => 'item']);
+
+        unset($subject['any']);
+        $this->assertFalse(isset($subject['any']), 'not set after deletion');
+        try {
+            $subject['any'];
+            $this->fail('Cannot access key after removal');
+        } catch (OutOfBoundsException) {
+            // Expected
+        }
+
+        $subject['any'] = 'new item';
+        $this->assertTrue(isset($subject['any']));
+        $this->assertSame('new item', $subject['any']);
+    }
+
+    public function test_it_is_iterable()
+    {
+        $subject = new UniqueMap(['any' => 'item']);
+        $subject['new'] = 'new1';
+        $subject['other'] = 'new2';
+
+        $this->assertSame(
+            ['any' => 'item', 'new' => 'new1', 'other' => 'new2'],
+            iterator_to_array($subject)
+        );
+    }
+
+    public function test_it_is_countable()
+    {
+        $subject = new UniqueMap(['any' => 'item']);
+        $subject['new'] = 'new1';
+        $subject['other'] = 'new2';
+
+        $this->assertSame(3, count($subject));
+    }
+
+    public function test_it_supports_conditional_read_like_an_array()
+    {
+        $subject = new UniqueMap(['i-exist' => 'ok']);
+        $this->assertSame('any-default', $subject['i do not'] ?? 'any-default');
+    }
+
+}

--- a/test/unit/Encryption/CryptoBox/CryptoBoxKeypairSetTest.php
+++ b/test/unit/Encryption/CryptoBox/CryptoBoxKeypairSetTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace test\unit\Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxKeypair;
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxKeypairSet;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+
+class CryptoBoxKeypairSetTest extends TestCase
+{
+
+    public function test_it_can_return_known_keypair_by_id()
+    {
+        $subject = new CryptoBoxKeypairSet(
+            CryptoBoxKeypair::generate('key-a'),
+            $expected = CryptoBoxKeypair::generate('key-b'),
+            CryptoBoxKeypair::generate('key-f'),
+        );
+
+        $this->assertSame(
+            $expected,
+            $subject->getKeypair('key-b')
+        );
+    }
+
+    public function test_it_throws_on_construction_with_duplicate_key_ids()
+    {
+        $a1 = CryptoBoxKeypair::generate('key-a');
+        $a2 = CryptoBoxKeypair::generate('key-a');
+        $this->expectException(\UnexpectedValueException::class);
+        new CryptoBoxKeypairSet($a1, $a2);
+    }
+
+    public function test_it_throws_on_request_for_undefined_key()
+    {
+        $subject = new CryptoBoxKeypairSet(
+            CryptoBoxKeypair::generate('one'),
+            CryptoBoxKeypair::generate('two'),
+            CryptoBoxKeypair::generate('three'),
+        );
+
+        $this->expectException(OutOfBoundsException::class);
+        $subject->getKeypair('four');
+    }
+
+    public function test_it_provides_shortcut_to_decrypt_a_value_with_known_key()
+    {
+        $subject = new CryptoBoxKeypairSet(
+            CryptoBoxKeypair::generate('a'),
+            $keypair = CryptoBoxKeypair::generate('b'),
+            CryptoBoxKeypair::generate('c'),
+        );
+
+        $encrypted = $keypair->getPublicKey()->encrypt('so secret');
+
+        $this->assertSame('so secret', $subject->decrypt($encrypted));
+        // Actual failure cases for decrypt are tested on the keypair itself
+    }
+
+    public function test_it_can_be_constructed_from_strings()
+    {
+        $kp1 = CryptoBoxKeypair::generate('one');
+        $kp2 = CryptoBoxKeypair::generate('two');
+        $kp3 = CryptoBoxKeypair::generate('three');
+
+        $subject = CryptoBoxKeypairSet::fromStrings(
+            $kp1->exportToString(),
+            $kp2->exportToString(),
+            $kp3->exportToString(),
+        );
+
+        $this->assertEquals($kp1, $subject->getKeypair('one'));
+        $this->assertEquals($kp2, $subject->getKeypair('two'));
+        $this->assertEquals($kp3, $subject->getKeypair('three'));
+    }
+
+}

--- a/test/unit/Encryption/CryptoBox/CryptoBoxKeypairTest.php
+++ b/test/unit/Encryption/CryptoBox/CryptoBoxKeypairTest.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+namespace test\unit\Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxKeypair;
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxString;
+use Ingenerator\PHPUtils\Encryption\CryptoBox\DecryptionFailedException;
+use Ingenerator\TrustIDIngress\ToExtract\SensitiveParameter;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use function str_replace;
+
+class CryptoBoxKeypairTest extends TestCase
+{
+    public function test_it_can_be_generated_as_a_new_keypair_and_used_to_decrypt()
+    {
+        $first_keypair = CryptoBoxKeypair::generate('any-id');
+        $this->assertSame('any-id', $first_keypair->keypair_id);
+
+        $encrypted = $first_keypair->getPublicKey()->encrypt('any-plain');
+        $this->assertSame(
+            'any-plain',
+            $first_keypair->decrypt($encrypted),
+            'Newly generated keypair can encrypt and decrypt'
+        );
+
+        // But a newly generated keypair cannot decrypt a value that was decrypted with something else.
+        $second_keypair = CryptoBoxKeypair::generate('any-id');
+        $this->expectException(DecryptionFailedException::class);
+        $second_keypair->decrypt($encrypted);
+    }
+
+    /**
+     * @testWith ["multi words"]
+     *           [""]
+     *           ["Whoopdedo!"]
+     */
+    public function test_it_cannot_be_created_with_keypair_id_in_invalid_format($key_id)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        CryptoBoxKeypair::generate($key_id);
+    }
+
+    public function test_it_can_be_converted_from_known_string_input_and_used_to_decrypt()
+    {
+        $subject = CryptoBoxKeypair::fromString(
+            'some-key.zio0N2IcV1QU637aor-JVG2yrbrY4iuCAE1YiCz6E5j7Y8LeZmysuvLZOgaIeZuQshSjvijpVhHoTSP-qmsfBA'
+        );
+        // To update the test value if required:
+        // $enc = $subject->getPublicKey()->encrypt('open sesame');
+        // print (string) $enc;
+        $this->assertSame(
+            'open sesame',
+            $subject->decrypt(
+                CryptoBoxString::fromString(
+                    'some-key._-mdoLEYjGXTx9eZyFDABgjT9ndnC2yvdjh1rshjIARIDdJPzOmkuQWhVxQv0I8oetCKzeOLDbBCzqU'
+                )
+            )
+        );
+    }
+
+    public function provider_invalid_keypair_string()
+    {
+        return [
+            'empty' => [''],
+            'incorrect format' => ['just a long string'],
+            'not base64url' => ['key-id."!&*£&C531()"£&$$$"!£'],
+            'no keypair_id' => ['zio0N2IcV1QU637aor-JVG2yrbrY4iuCAE1YiCz6E5j7Y8LeZmysuvLZOgaIeZuQshSjvijpVhHoTSP-qmsfBA'],
+            'keypair is too short' => ['some-key.cnViYmlzaA'],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_invalid_keypair_string
+     */
+    public function test_it_throws_invalid_argument_if_attempting_to_create_from_invalid_string($keypair_string)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        CryptoBoxKeypair::fromString($keypair_string);
+    }
+
+    public function test_it_throws_decryption_failed_if_attempting_to_decrypt_crypto_box_string_for_different_key_id()
+    {
+        // It doesn't matter that in this example they have the same actual keypair value, they are different key IDs
+        // and should be treated as an error to try and decrypt a value with the wrong key
+        $kp1 = CryptoBoxKeypair::generate('any-id');
+        $enc = $kp1->getPublicKey()->encrypt('any value');
+
+        // Have to really work to force the wrong key ID onto this!
+        $keypair_string = str_replace('any-id.', 'wrong-id.', $kp1->exportToString());
+
+        $this->expectException(DecryptionFailedException::class);
+        $this->expectExceptionMessage('incorrect key');
+        CryptoBoxKeypair::fromString($keypair_string)->decrypt($enc);
+    }
+
+    public function provider_bad_decryption()
+    {
+        return [
+            'valid as a key, but not for this message' => [
+                CryptoBoxKeypair::generate('a')->exportToString(),
+            ],
+            // I don't think there actually are any cases where the keypair provided can be invalid, because we
+            // validate and throw at the point of construction.
+        ];
+    }
+
+    /**
+     * @dataProvider provider_bad_decryption
+     */
+    public function test_it_throws_decryption_failed_with_incorrect_key($bad_keypair)
+    {
+        $encrypted = CryptoBoxKeypair::generate('a')
+            ->getPublicKey()
+            ->encrypt('i-am-a-secret');
+
+        $subject = CryptoBoxKeypair::fromString($bad_keypair);
+
+        $this->expectException(DecryptionFailedException::class);
+        $subject->decrypt($encrypted);
+    }
+
+    public function test_it_throws_decryption_failed_if_ciphertext_has_been_tampered_with()
+    {
+        // Don't need to cover every case, we can trust that libsodium will deal with it, we just need to validate
+        // that we are catching & throwing on the sodium failure
+        $keypair = CryptoBoxKeypair::generate('a');
+        $genuine_msg = $keypair->getPublicKey()->encrypt('sesame');
+
+        $tampered_msg = new CryptoBoxString(
+            ciphertext: $genuine_msg->ciphertext.'p', keypair_id: $genuine_msg->keypair_id
+        );
+        $this->expectException(DecryptionFailedException::class);
+        $this->expectExceptionMessage('invalid key');
+        $keypair->decrypt($tampered_msg);
+    }
+
+    public function test_it_can_be_converted_to_urlsafe_base64_and_recreated_with_all_data()
+    {
+        $expected = CryptoBoxKeypair::generate('key-one');
+        $exported = $expected->exportToString();
+        $this->assertMatchesRegularExpression('/^key-one\.[a-zA-Z0-9_-]+$/', $exported, 'Should be base64url encoded');
+
+        $this->assertEquals(
+            $expected,
+            CryptoBoxKeypair::fromString($exported)
+        );
+    }
+}

--- a/test/unit/Encryption/CryptoBox/CryptoBoxPublicKeyTest.php
+++ b/test/unit/Encryption/CryptoBox/CryptoBoxPublicKeyTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace test\unit\Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxKeypair;
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxPublicKey;
+use PHPUnit\Framework\TestCase;
+
+class CryptoBoxPublicKeyTest extends TestCase
+{
+
+    /*
+     * See also the tests for CryptoBoxKeypair which cover some behaviour of the public key object
+     * by testing through the behaviour of the public key.
+     */
+
+    public function test_it_can_be_created_from_a_known_string_input_and_used_to_encrypt()
+    {
+        $subject = CryptoBoxPublicKey::fromString('some-key.-J5fsjd53SB2lLmTVcGC0k0w59d9E-qBOYVcuDzUpRU');
+        $encrypted = $subject->encrypt('open sesame');
+
+        $this->assertSame(
+            'open sesame',
+            CryptoBoxKeypair::fromString(
+                'some-key.waq2hJFuWww5NW7v8XNggBsIp9KOP2MiW1fv6B7URwf4nl-yN3ndIHaUuZNVwYLSTTDn130T6oE5hVy4PNSlFQ'
+            )
+                ->decrypt($encrypted)
+        );
+    }
+
+    public function provider_invalid_keypair_string()
+    {
+        return [
+            'empty' => [''],
+            'incorrect format' => ['just a long string'],
+            'not base64url' => ['key-id."!&*£&C531()"£&$$$"!£'],
+            'no keypair_id' => ['-J5fsjd53SB2lLmTVcGC0k0w59d9E-qBOYVcuDzUpRU'],
+            'keypair is too short' => ['some-key.cnViYmlzaA'],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_invalid_keypair_string
+     */
+    public function test_it_throws_on_attempt_to_create_from_invalid_string($invalid)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        CryptoBoxPublicKey::fromString($invalid);
+    }
+
+    public function test_it_can_be_converted_to_a_urlsafe_base64_string_and_back()
+    {
+        $expected = CryptoBoxKeypair::generate('key-one')->getPublicKey();
+
+        $exported = (string) $expected;
+        $this->assertMatchesRegularExpression('/^key-one\.[a-zA-Z0-9_-]+$/', $exported, 'Should be base64url encoded');
+
+        $this->assertEquals(
+            $expected,
+            CryptoBoxPublicKey::fromString($exported)
+        );
+    }
+}

--- a/test/unit/Encryption/CryptoBox/CryptoBoxStringTest.php
+++ b/test/unit/Encryption/CryptoBox/CryptoBoxStringTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace test\unit\Ingenerator\PHPUtils\Encryption\CryptoBox;
+
+use Ingenerator\PHPUtils\Encryption\CryptoBox\CryptoBoxString;
+use Ingenerator\PHPUtils\StringEncoding\Base64Url;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use function random_bytes;
+
+class CryptoBoxStringTest extends TestCase
+{
+    /*
+     * Heavily tested through the tests for CryptoBoxKeypair and CryptoBoxPublicKey
+     */
+
+    public function provider_invalid_string_format()
+    {
+        return [
+            'empty' => [''],
+            'incorrect format' => ['just a long string'],
+            'not base64url' => ['key-id."!&*£&C531()"£&$$$"!£'],
+            'no keypair_id' => ['zio0N2IcV1QU637aor-JVG2yrbrY4iuCAE1YiCz6E5j7Y8LeZmysuvLZOgaIeZuQshSjvijpVhHoTSP-qmsfBA'],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_invalid_string_format
+     */
+    public function test_it_throws_invalid_argument_if_attempting_to_create_from_invalid_string($keypair_string)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        CryptoBoxString::fromString($keypair_string);
+    }
+
+    public function test_it_can_be_converted_to_string_encoding_and_recreated()
+    {
+        $expected = new CryptoBoxString(ciphertext: random_bytes(21), keypair_id: 'b');
+        $exported = (string) $expected;
+
+        $this->assertMatchesRegularExpression('/^b\.[a-zA-Z0-9_-]+$/', $exported, 'Should be base64url encoded');
+
+        $this->assertEquals(
+            $expected,
+            CryptoBoxString::fromString($exported)
+        );
+    }
+
+    public function test_it_can_provide_just_the_ciphertext_as_base64()
+    {
+        $original = random_bytes(23);
+        $subject = new CryptoBoxString(ciphertext: $original, keypair_id: 'alpha');
+
+        $this->assertSame($original, Base64Url::decode($subject->getCiphertextB64()));
+    }
+
+}


### PR DESCRIPTION
And a utility `UniqueMap` class for cases where you want an associative array that throws if you try to overwrite an existing key or access one that is undefined.