### PR TITLE
Fix the dockblock typehint for InitialisableSingletonTrait::instance()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix the docblock typehint for InitialisableSingletonTrait so that ::instance() to @return static
+
 ### v1.19.0 (2023-03-17)
 
 * Add very light wrapper around the native sodium_crypto_box_seal... functions for anonymous public-key encryption.

--- a/src/Object/InitialisableSingletonTrait.php
+++ b/src/Object/InitialisableSingletonTrait.php
@@ -14,7 +14,7 @@ trait  InitialisableSingletonTrait
     /**
      * Return the singleton instance
      *
-     * @return object
+     * @return static
      * @throws SingletonNotInitialisedException if the class has not been initialised
      */
     public static function instance()


### PR DESCRIPTION
It was phpdoced as @return object which meant calls to MyClass::instance() couldn't properly detect the type of object in IDE etc.

Leave the actual typehint alone for now, to avoid a BC break on any classes that use the trait but reimplement that method, but the docblock can change without any issues.