### PR TITLE
Truncate user_agent to fit session database column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix bug where devices with long user agents generated a database exception when attempting to create a session. 
+
 ### v1.19.2 (2023-04-27)
 
 * Add assertCapturedOneExactTimer helper. Allowing you to simultaneously assert only 

--- a/src/Session/MysqlSession.php
+++ b/src/Session/MysqlSession.php
@@ -168,7 +168,7 @@ class MysqlSession implements SessionHandlerInterface, \SessionUpdateTimestampHa
                 'hash'       => $this->calculateHash(),
                 'data'       => '',
                 'now'        => \date('Y-m-d H:i:s'),
-                'user_agent' => $this->client_user_agent,
+                'user_agent' => mb_substr($this->client_user_agent, 0, 255),
                 'ip'         => $this->client_ip,
             ]
         );


### PR DESCRIPTION
We only store it for debugging / visibility, this was previously happening automatically due to mysql non-strict behaviour but we now need to do it manually to avoid a strict mode error.