### PR TITLE
Don't escape `/` in StackdriverApplicationLogger logs and optionally in other JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### v2.1.1 (2024-09-13)
+
 * Support specifying unescaped-slashes in `JSON::encode()`
 * Don't escape `/` in JSON-encoded log payloads from StackdriverApplicationLogger
 * Ensure StackdriverApplicationLogger can always log even with invalid UTF8 characters anywhere in payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Support specifying unescaped-slashes in `JSON::encode()`
 * Don't escape `/` in JSON-encoded log payloads from StackdriverApplicationLogger
 * Ensure StackdriverApplicationLogger can always log even with invalid UTF8 characters anywhere in payload
 * Fix session & logging bugs when incoming user-agent contains invalid UTF8 or escape characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Don't escape `/` in JSON-encoded log payloads from StackdriverApplicationLogger
 * Ensure StackdriverApplicationLogger can always log even with invalid UTF8 characters anywhere in payload
 * Fix session & logging bugs when incoming user-agent contains invalid UTF8 or escape characters
 

--- a/src/Logging/StackdriverApplicationLogger.php
+++ b/src/Logging/StackdriverApplicationLogger.php
@@ -384,7 +384,10 @@ class StackdriverApplicationLogger extends AbstractLogger
         try {
             $success = file_put_contents(
                 $this->log_destination,
-                json_encode($log_entry, JSON_INVALID_UTF8_SUBSTITUTE)."\n",
+                json_encode(
+                    $log_entry,
+                    JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES
+                )."\n",
                 FILE_APPEND
             );
 

--- a/src/StringEncoding/JSON.php
+++ b/src/StringEncoding/JSON.php
@@ -34,9 +34,26 @@ class JSON
         return $value ?: [];
     }
 
-    public static function encode($value, bool $pretty = TRUE): string
-    {
-        $json = json_encode($value, $pretty ? JSON_PRETTY_PRINT : 0);
+    /**
+     * @param mixed $value
+     * @param bool $pretty
+     * @param bool $escaped_slashes defaults true to match the PHP default
+     *
+     * @return string
+     * @throws \Ingenerator\PHPUtils\StringEncoding\InvalidJSONException
+     */
+    public static function encode(
+        $value,
+        bool $pretty = true,
+        bool $escaped_slashes = true,
+    ): string {
+        $flags = (
+            ($pretty ? JSON_PRETTY_PRINT : 0)
+            |
+            ($escaped_slashes ? 0 : JSON_UNESCAPED_SLASHES)
+        );
+
+        $json = json_encode($value, $flags);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new \Ingenerator\PHPUtils\StringEncoding\InvalidJSONException('Could not encode as JSON : ' . json_last_error_msg());
         }

--- a/src/StringEncoding/JSON.php
+++ b/src/StringEncoding/JSON.php
@@ -3,7 +3,7 @@
 namespace Ingenerator\PHPUtils\StringEncoding;
 
 use Ingenerator\PHPUtils\StringEncoding\InvalidJSONException;
-use function json_last_error_msg;
+use JsonException;
 
 class JSON
 {
@@ -16,13 +16,11 @@ class JSON
             throw new InvalidJSONException('Invalid JSON: Cannot decode a null value');
         }
 
-        $result = json_decode($json, TRUE);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new InvalidJSONException('Invalid JSON: '.json_last_error_msg());
+        try {
+            return json_decode($json, associative: true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidJSONException('Invalid JSON: '.$e->getMessage());
         }
-
-        return $result;
     }
 
     public static function decodeArray(string $json): array
@@ -40,7 +38,6 @@ class JSON
      * @param bool $escaped_slashes defaults true to match the PHP default
      *
      * @return string
-     * @throws \Ingenerator\PHPUtils\StringEncoding\InvalidJSONException
      */
     public static function encode(
         $value,
@@ -51,13 +48,15 @@ class JSON
             ($pretty ? JSON_PRETTY_PRINT : 0)
             |
             ($escaped_slashes ? 0 : JSON_UNESCAPED_SLASHES)
+            |
+            JSON_THROW_ON_ERROR
         );
 
-        $json = json_encode($value, $flags);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \Ingenerator\PHPUtils\StringEncoding\InvalidJSONException('Could not encode as JSON : ' . json_last_error_msg());
+        try {
+            return json_encode($value, $flags);
+        } catch (JsonException $e) {
+            throw new InvalidJSONException('Could not encode as JSON: '.$e->getMessage());
         }
-        return $json;
     }
 
     /**


### PR DESCRIPTION
Reduce the payload size on the wire for the JSON StackdriverApplicationLogger entries, by avoiding the redundant encoding of `/` as `\/` in the output.

Additionally, provide an `escaped_slashes` option to `JSON::encode` (defaulting true to match current behaviour) to allow for not escaping slashes in application-generated JSON.